### PR TITLE
Add `--include` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,30 @@
 # [unreleased]
 
+- Add a new `--include` option that only shows given packages.
+
 # 1.4.0
 
-* Add the `--root` option to specify a subset of a workspace's crates you want
+- Add the `--root` option to specify a subset of a workspace's crates you want
   to get the dependency graph for
-* Only include proc-macro crates in the graph if `--build-deps` is used
+- Only include proc-macro crates in the graph if `--build-deps` is used
 
 # 1.3.1
 
-* Upgrade dependencies
+- Upgrade dependencies
 
 # 1.3.0
 
-* Add the `--workspace-only` option to get a graph of just the workspace
+- Add the `--workspace-only` option to get a graph of just the workspace
   packages
-* Make the `--help` output prettier by upgrading to clap version `4.0.0-rc.2`
+- Make the `--help` output prettier by upgrading to clap version `4.0.0-rc.2`
 
 # 1.2.5
 
-* Upgrade dependencies
+- Upgrade dependencies
 
 # 1.2.4
 
-* Fix some invalid handling of `cargo metadata` output that lead to inaccurate
+- Fix some invalid handling of `cargo metadata` output that lead to inaccurate
   output and the warning
 
   ```
@@ -33,35 +35,35 @@
 
 # 1.2.3
 
-* Upgrade dependencies
+- Upgrade dependencies
 
 # 1.2.2
 
-* Fix `--exclude` not working for workspace members
+- Fix `--exclude` not working for workspace members
 
 # 1.2.1
 
-* Calculate dependency kinds correctly in all cases
-* Detect whether a crate is optional correctly in all cases
-  * Previously, a crate with a hyphen in its crates.io name would never be shown
+- Calculate dependency kinds correctly in all cases
+- Detect whether a crate is optional correctly in all cases
+  - Previously, a crate with a hyphen in its crates.io name would never be shown
     as optional
 
 # 1.2.0
 
-* Rename `--exclude` to `--hide`
-* Add a new `--exclude` option that is the same as `--hide`, except that it
+- Rename `--exclude` to `--hide`
+- Add a new `--exclude` option that is the same as `--hide`, except that it
   doesn't take the crate(s) in question into account for dependency kind
   resolution
-* Improve handling of proc-macro crates in the workspace
+- Improve handling of proc-macro crates in the workspace
 
 # 1.1.2
 
-* Fix excessive whitespace in option descriptions in `--help`
+- Fix excessive whitespace in option descriptions in `--help`
 
 # 1.1.1
 
-* Mark proc-macro crates in the workspace as build dependencies
+- Mark proc-macro crates in the workspace as build dependencies
 
 # 1.1.0
 
-* Add the `--focus` option
+- Add the `--focus` option

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ pub(crate) struct Config {
     pub dedup_transitive_deps: bool,
     pub hide: Vec<String>,
     pub exclude: Vec<String>,
+    pub include: Vec<String>,
     pub root: Vec<String>,
     pub workspace_only: bool,
     pub focus: Vec<String>,
@@ -81,6 +82,17 @@ pub(crate) fn parse_options() -> Config {
                              as multiple arguments\n\n\
                              In constrast to --hide, excluded packages will not contribute in \
                              dependency kind resolution",
+                        ),
+                )
+                .arg(
+                    Arg::new("include")
+                        .long("include")
+                        .action(ArgAction::Append)
+                        .value_delimiter(',')
+                        .help(
+                            "Package name(s) to include; can be given as a comma-separated list or \
+                             as multiple arguments\n\n\
+                             Only included packages will be shown",
                         ),
                 )
                 .arg(
@@ -183,6 +195,7 @@ pub(crate) fn parse_options() -> Config {
     let dedup_transitive_deps = matches.get_flag("dedup_transitive_deps");
     let hide = matches.get_many("hide").map_or_else(Vec::new, collect_owned);
     let exclude = matches.get_many("exclude").map_or_else(Vec::new, collect_owned);
+    let include = matches.get_many("include").map_or_else(Vec::new, collect_owned);
     let root = matches.get_many("root").map_or_else(Vec::new, collect_owned);
     let workspace_only = matches.get_flag("workspace_only");
     let focus = matches.get_many("focus").map_or_else(Vec::new, collect_owned);
@@ -204,6 +217,7 @@ pub(crate) fn parse_options() -> Config {
         dedup_transitive_deps,
         hide,
         exclude,
+        include,
         root,
         workspace_only,
         focus,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,7 @@ pub(crate) fn parse_options() -> Config {
                             "Package name(s) to hide; can be given as a comma-separated list or \
                              as multiple arguments\n\n\
                              In contrast to --exclude, hidden packages will still contribute in \
-                             dependency kind resolution.",
+                             dependency kind resolution",
                         ),
                 )
                 .arg(
@@ -80,7 +80,7 @@ pub(crate) fn parse_options() -> Config {
                         .help(
                             "Package name(s) to ignore; can be given as a comma-separated list or \
                              as multiple arguments\n\n\
-                             In constrast to --hide, excluded packages will not contribute in \
+                             In contrast to --hide, excluded packages will not contribute in \
                              dependency kind resolution",
                         ),
                 )

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -97,7 +97,7 @@ pub(crate) fn remove_irrelevant_deps(graph: &mut DepGraph, focus: &[String]) {
     }
 }
 
-pub(crate) fn remove_deps(graph: &mut DepGraph, exclude: &[String]) {
+pub(crate) fn remove_deps(graph: &mut DepGraph, hide: &[String]) {
     let mut visit_queue: VecDeque<_> = graph.node_indices().collect();
     while let Some(idx) = visit_queue.pop_front() {
         // A node can end up being in the list multiple times. If it was already removed by a
@@ -107,13 +107,14 @@ pub(crate) fn remove_deps(graph: &mut DepGraph, exclude: &[String]) {
         }
 
         let pkg = &graph[idx];
-        let is_excluded = exclude.contains(&pkg.name);
 
-        if !is_excluded
+        let is_hidden = hide.contains(&pkg.name);
+
+        if !is_hidden
             && (graph.neighbors_directed(idx, Direction::Incoming).next().is_some()
                 || pkg.is_ws_member)
         {
-            // If the package is not explicitly excluded, and also has incoming edges or is a
+            // If the package is not explicitly hidden, and also has incoming edges or is a
             // workspace members, don't remove it and continue with the queue.
             continue;
         }

--- a/src/graph/build.rs
+++ b/src/graph/build.rs
@@ -67,9 +67,11 @@ pub(crate) fn get_dep_graph(metadata: Metadata, config: &Config) -> anyhow::Resu
             // Same as dep.name in most cases, but not if it got renamed in parent's Cargo.toml
             let dep_crate_name = &get_package(&metadata.packages, &dep.pkg).name;
 
+            // Excludes are specified and include this package
             if config.exclude.contains(dep_crate_name)
                 // Includes are specified and do not include this package
                 || (!config.include.is_empty() && !config.include.contains(dep_crate_name))
+                // This dependency should be skipped because of its dep_kinds
                 || dep.dep_kinds.iter().all(|i| skip_dep(config, i))
             {
                 continue;

--- a/src/graph/build.rs
+++ b/src/graph/build.rs
@@ -32,9 +32,11 @@ pub(crate) fn get_dep_graph(metadata: Metadata, config: &Config) -> anyhow::Resu
         let pkg = get_package(&metadata.packages, pkg_id);
 
         // Roots are specified explicitly and don't contain this package
-        if !(config.root.is_empty() || config.root.contains(&pkg.name))
+        if (!config.root.is_empty() && !config.root.contains(&pkg.name))
             // Excludes are specified and include this package
             || config.exclude.contains(&pkg.name)
+            // Includes are specified and do not include this package
+            || (!config.include.is_empty() && !config.include.contains(&pkg.name))
             // Build dependencies are disabled and this package is a proc-macro
             || !config.build_deps && is_proc_macro(pkg)
         {
@@ -66,6 +68,8 @@ pub(crate) fn get_dep_graph(metadata: Metadata, config: &Config) -> anyhow::Resu
             let dep_crate_name = &get_package(&metadata.packages, &dep.pkg).name;
 
             if config.exclude.contains(dep_crate_name)
+                // Includes are specified and do not include this package
+                || (!config.include.is_empty() && !config.include.contains(dep_crate_name))
                 || dep.dep_kinds.iter().all(|i| skip_dep(config, i))
             {
                 continue;


### PR DESCRIPTION
I'd like to only show my workspace packages and a few relevant dependencies. This is much simpler using inclusion han exclusion, where I have to explicitly ignore all the dependencies of the few deps I want to show.