### PR TITLE
added `--direct-dependencies-only` option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,7 +113,7 @@ pub(crate) fn parse_options() -> Config {
                     Arg::new("direct_dependencies_only")
                         .long("direct-dependencies-only")
                         .action(ArgAction::SetTrue)
-                        .help("Only list direct workspace dependencies"),
+                        .help("Only list direct dependencies of workspace crates"),
                 )
                 .arg(
                     Arg::new("focus")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ pub(crate) struct Config {
     pub include: Vec<String>,
     pub root: Vec<String>,
     pub workspace_only: bool,
+    pub direct_dependencies_only: bool,
     pub focus: Vec<String>,
 
     pub features: Vec<String>,
@@ -109,6 +110,12 @@ pub(crate) fn parse_options() -> Config {
                         .help("Exclude all packages outside of the workspace"),
                 )
                 .arg(
+                    Arg::new("direct_dependencies_only")
+                        .long("direct-dependencies-only")
+                        .action(ArgAction::SetTrue)
+                        .help("Only list direct workspace dependencies"),
+                )
+                .arg(
                     Arg::new("focus")
                         .long("focus")
                         .action(ArgAction::Append)
@@ -198,6 +205,7 @@ pub(crate) fn parse_options() -> Config {
     let include = matches.get_many("include").map_or_else(Vec::new, collect_owned);
     let root = matches.get_many("root").map_or_else(Vec::new, collect_owned);
     let workspace_only = matches.get_flag("workspace_only");
+    let direct_dependencies_only = matches.get_flag("direct_dependencies_only");
     let focus = matches.get_many("focus").map_or_else(Vec::new, collect_owned);
 
     let features = matches.get_many("features").map_or_else(Vec::new, collect_owned);
@@ -220,6 +228,7 @@ pub(crate) fn parse_options() -> Config {
         include,
         root,
         workspace_only,
+        direct_dependencies_only,
         focus,
         features,
         all_features,
@@ -233,9 +242,9 @@ pub(crate) fn parse_options() -> Config {
     }
 }
 
-fn collect_owned<'a, T>(iter: impl Iterator<Item = &'a T>) -> Vec<T>
-where
-    T: ?Sized + Clone + 'a,
+fn collect_owned<'a, T>(iter: impl Iterator<Item=&'a T>) -> Vec<T>
+    where
+        T: ?Sized + Clone + 'a,
 {
     iter.cloned().collect()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -242,9 +242,9 @@ pub(crate) fn parse_options() -> Config {
     }
 }
 
-fn collect_owned<'a, T>(iter: impl Iterator<Item=&'a T>) -> Vec<T>
-    where
-        T: ?Sized + Clone + 'a,
+fn collect_owned<'a, T>(iter: impl Iterator<Item = &'a T>) -> Vec<T>
+where
+    T: ?Sized + Clone + 'a,
 {
     iter.cloned().collect()
 }

--- a/src/graph/build.rs
+++ b/src/graph/build.rs
@@ -98,7 +98,12 @@ pub(crate) fn get_dep_graph(metadata: Metadata, config: &Config) -> anyhow::Resu
                     }
 
                     let idx = graph.add_node(dep_pkg);
-                    deps_add_queue.push_back(dep.pkg.clone());
+
+                    // Don't add any more dependencies to the queue if we only want direct dependencies
+                    if !config.direct_dependencies_only {
+                        deps_add_queue.push_back(dep.pkg.clone());
+                    }
+
                     v.insert(idx);
                     idx
                 }


### PR DESCRIPTION
This adds the option to only add crates to graph that are direct dependencies of workspace members.
Right now i imitate this feature by adding all workspace crates into the `focus`, and though that works, having this options would be much easier.

Is this something you would want to add to this crate?