### PR TITLE
feat: interactive HTML output via viz-network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +76,7 @@ name = "cargo-depgraph"
 version = "1.6.0"
 dependencies = [
  "anyhow",
+ "base64",
  "cargo_metadata",
  "clap",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [".gitignore", ".rustfmt.toml", "*.png"]
 
 [dependencies]
 anyhow = "1.0.38"
+base64 = "0.22.1"
 cargo_metadata = "0.18.0"
 clap = "4.0.18"
 petgraph = { version = "0.6.0", default-features = false, features = ["stable_graph"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub(crate) struct Config {
     pub workspace_only: bool,
     pub focus: Vec<String>,
     pub depth: Option<u32>,
+    pub html: bool,
 
     pub features: Vec<String>,
     pub all_features: bool,
@@ -157,6 +158,12 @@ pub(crate) fn parse_options() -> Config {
                         .value_name("TRIPLE"),
                 )
                 .arg(
+                    Arg::new("html")
+                        .long("html")
+                        .help("Generate interactive HTML output")
+                        .action(ArgAction::SetTrue)
+                )
+                .arg(
                     Arg::new("manifest_path")
                         .long("manifest-path")
                         .help("Path to Cargo.toml")
@@ -217,6 +224,7 @@ pub(crate) fn parse_options() -> Config {
     let frozen = matches.get_flag("frozen");
     let locked = matches.get_flag("locked");
     let offline = matches.get_flag("offline");
+    let html = matches.get_flag("html");
     let unstable_flags = matches.get_many("unstable_flags").map_or_else(Vec::new, collect_owned);
 
     Config {
@@ -231,6 +239,7 @@ pub(crate) fn parse_options() -> Config {
         workspace_only,
         focus,
         depth,
+        html,
         features,
         all_features,
         no_default_features,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use std::iter;
+use std::{fmt::Display, iter};
 
 use cargo_metadata::MetadataCommand;
+use output::html;
 
 // `DepInfo` represents the data associated with dependency graph edges
 mod dep_info;
@@ -70,7 +71,8 @@ fn main() -> anyhow::Result<()> {
     }
     set_name_stats(&mut graph);
 
-    println!("{:?}", dot(&graph));
+    let output: &dyn Display = if config.html { &html(&graph) } else { &dot(&graph) };
+    println!("{output}");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, iter};
+use std::iter;
 
 use cargo_metadata::MetadataCommand;
 use output::html;
@@ -71,8 +71,7 @@ fn main() -> anyhow::Result<()> {
     }
     set_name_stats(&mut graph);
 
-    let output: &dyn Display = if config.html { &html(&graph) } else { &dot(&graph) };
-    println!("{output}");
+    println!("{}", if config.html { html(&graph) } else { dot(&graph, false) });
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds a new html output format(`--html`) that is interactive:

![image](https://github.com/user-attachments/assets/51f575e1-5dbd-4a64-b6dc-100fb0257902)

Because the dot parser of viz-network is not fully compliant with graphviz(e.g. color attr is applied to both border and background), I have to do some manual style tweaking in 964a578e5ff5e51a600a907368ee65ba2c5564a2 to avoid messed up eye hurting colors.